### PR TITLE
Add optional Qobuz token support and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,102 @@ SpotiFLAC(
     use_album_subfolders=True,
     loop=60 # Retry duration in minutes
 )
-
 ```
+
+
+## Qobuz Token (Optional)
+
+Setting a personal Qobuz token improves metadata resolution reliability. The token is used as a **last resort fallback** — requests are first attempted anonymously, and only if they fail (HTTP 400/401) the token is injected. A **free Qobuz account** is sufficient.
+
+> **Important:** Use throwaway credentials (random email + password you won't forget). You'll need them again if the token expires and needs to be regenerated.
+
+### How to Create a Free Account
+
+Go to [qobuz.com](https://www.qobuz.com) and register. No payment method required for the free tier.
+
+### How to Extract Your Token
+
+1. Log in to [play.qobuz.com](https://play.qobuz.com)
+2. Open DevTools with **F12** → go to the **Network** tab
+3. Play any track or perform any search to trigger API calls
+4. Filter requests by typing `api.json` in the search bar
+5. Click on any request to `www.qobuz.com/api.json/...`
+6. In the **Request Headers** panel, look for: **x-user-auth-token: your_token_here**
+7. Copy the value — that is your token
+
+---
+
+### Setting the Token
+
+#### Environment Variable (all platforms)
+
+The recommended approach across all systems:
+
+```bash
+export QOBUZ_AUTH_TOKEN="your_token_here"
+```
+On Windows (Command Prompt):
+```bash
+set QOBUZ_AUTH_TOKEN=your_token_here
+```
+On Windows (PowerShell):
+```bash
+$env:QOBUZ_AUTH_TOKEN="your_token_here"
+```
+To make it permanent on Linux/macOS, add the export line to your **~/.bashrc, ~/.zshrc**, or equivalent shell config file.
+
+**Python**
+```python
+from SpotiFLAC import SpotiFLAC
+
+SpotiFLAC(
+    url="https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT",
+    output_dir="./downloads",
+    qobuz_token="your_token_here"
+)
+```
+Alternatively, set the environment variable before running and omit the parameter entirely.
+**Docker**
+Pass the token as an environment variable at runtime:
+```bash
+docker run \
+  -e QOBUZ_AUTH_TOKEN="your_token_here" \
+  -v ./downloads:/downloads \
+  your-spotiflac-image
+```
+
+Or define it in your **docker-compose.yml**:
+```yaml
+services:
+    spotiflac:
+        image: your-spotiflac-image
+        environment:
+            - QOBUZ_AUTH_TOKEN=your_token_here
+        volumes:
+            - ./downloads:/downloads
+```
+
+> **Never hardcode the token in a Dockerfile**: use environment variables or a .env file (excluded from version control via .gitignore).
+
+**.env File**
+If you prefer a local config file (useful for development):
+```env
+QOBUZ_AUTH_TOKEN=your_token_here
+```
+Load it before running:
+```bash
+export $(cat .env | xargs) && python launcher.py ...
+```
+Or with Docker Compose:
+```yaml
+services:
+  spotiflac:
+    env_file:
+      - .env
+```
+> Add **.env** to your **.gitignore** to avoid accidentally committing your token.
+
+
 <h2>CLI program usage</h2>
 <p>Program can be downloaded for <b>Windows</b>, <b>Linux (x86 and ARM)</b> and <b>MacOS</b>. The downloads are available under the releases.<br>
 Program can also be ran by downloading the python files and calling <code>python launcher.py</code> with the arguments.</p>
@@ -109,6 +203,8 @@ chmod +x SpotiFLAC-Linux-arm64
 | **`use_artist_subfolders`** | `bool` | `False` | Automatically organizes downloaded files into subfolders by artist. |
 | **`use_album_subfolders`** | `bool` | `False` | Automatically organizes downloaded files into subfolders by album. |
 | **`loop`** | `int` | `None` | Duration in minutes to keep retrying failed downloads. |
+| **`qobuz_token`** | `str` | `None` | Optional Qobuz user auth token used as fallback for metadata resolution. |
+
 
 ### Filename Format Placeholders
 

--- a/SpotiFLAC/providers/qobuz.py
+++ b/SpotiFLAC/providers/qobuz.py
@@ -99,9 +99,9 @@ class QobuzCredentials:
 
     def is_fresh(self) -> bool:
         return (
-            bool(self.app_id)
-            and bool(self.app_secret)
-            and (time.time() - self.fetched_at) < _CREDS_TTL
+                bool(self.app_id)
+                and bool(self.app_secret)
+                and (time.time() - self.fetched_at) < _CREDS_TTL
         )
 
     def to_dict(self) -> dict:
@@ -289,11 +289,12 @@ class QobuzProvider(BaseProvider):
     # ------------------------------------------------------------------
 
     def _do_signed_get(
-        self,
-        path:          str,
-        params:        dict,
-        creds:         QobuzCredentials | None = None,
-        force_refresh: bool = False,
+            self,
+            path:               str,
+            params:             dict,
+            creds:              QobuzCredentials | None = None,
+            force_refresh:      bool = False,
+            use_fallback_token: bool = False,
     ) -> requests.Response:
         if creds is None:
             creds = self._get_credentials(force_refresh=force_refresh)
@@ -307,24 +308,37 @@ class QobuzProvider(BaseProvider):
             "request_ts":  timestamp,
             "request_sig": signature,
         }
-        url  = f"{_API_BASE}/{path.strip('/')}"
-
+        url     = f"{_API_BASE}/{path.strip('/')}"
         headers = {"X-App-Id": creds.app_id}
-        if creds.user_auth_token:
+
+        if creds.user_auth_token and use_fallback_token:
             headers["X-User-Auth-Token"] = creds.user_auth_token
 
-        resp = self._session.get(
-            url, params=req_params,
-            headers=headers,
-            timeout=20,
-        )
+        resp = self._session.get(url, params=req_params, headers=headers, timeout=20)
 
-        # qobuzShouldRefreshCredentials: 400 o 401 → refresh e riprova
-        if resp.status_code in (400, 401) and not force_refresh:
-            logger.info("[qobuz] HTTP %s — forcing credential refresh", resp.status_code)
-            return self._do_signed_get(path, params, force_refresh=True)
+        if resp.status_code in (400, 401):
+            # Step 1 — prova con token personale (se disponibile e non ancora usato)
+            if creds.user_auth_token and not use_fallback_token and not force_refresh:
+                logger.info("[qobuz] HTTP %s — retry con token personale", resp.status_code)
+                return self._do_signed_get(
+                    path, params, creds=creds,
+                    force_refresh=False, use_fallback_token=True,
+                )
+
+            # Step 2 — token usato ma ancora 401: forza refresh credenziali
+            #           Propaga use_fallback_token=True per riusare il token
+            #           con le credenziali fresche
+            if not force_refresh:
+                logger.info("[qobuz] HTTP %s — credential refresh (token=%s)",
+                            resp.status_code, use_fallback_token)
+                return self._do_signed_get(
+                    path, params,
+                    force_refresh=True,
+                    use_fallback_token=use_fallback_token,  # ← propagato
+                )
 
         return resp
+
 
     # ------------------------------------------------------------------
     # Track lookup
@@ -432,19 +446,19 @@ class QobuzProvider(BaseProvider):
 
 
     def download_track(
-        self,
-        metadata:   TrackMetadata,
-        output_dir: str,
-        *,
-        filename_format:     str  = "{title} - {artist}",
-        position:            int  = 1,
-        include_track_num:   bool = False,
-        use_album_track_num: bool = False,
-        first_artist_only:   bool = False,
-        allow_fallback:      bool = True,
-        quality:             str  = "6",
-        embed_genre:         bool = True,
-        single_genre:        bool = True,
+            self,
+            metadata:   TrackMetadata,
+            output_dir: str,
+            *,
+            filename_format:     str  = "{title} - {artist}",
+            position:            int  = 1,
+            include_track_num:   bool = False,
+            use_album_track_num: bool = False,
+            first_artist_only:   bool = False,
+            allow_fallback:      bool = True,
+            quality:             str  = "6",
+            embed_genre:         bool = True,
+            single_genre:        bool = True,
     ) -> DownloadResult:
         try:
             if not metadata.isrc:


### PR DESCRIPTION
This PR changes how the Qobuz personal token (X-User-Auth-Token) is handled during API requests. It transitions the token usage from being the primary authentication method to a safer "fallback" mechanism, protecting the user's personal account from rate limits and potential bans during bulk downloads.

1. The Original Qobuz Logic (Before this PR)
Previously, the logic was very direct and somewhat "aggressive":

Immediate Usage: If a token was provided (via environment variable or JSON file), the script immediately injected it into the X-User-Auth-Token header from the very first request.

The Result: All metadata searches (track/search, track/get) were routed through the user's personal account. If you downloaded 1,000 tracks, you made 1,000 API calls under your own account.

The Problem: Bulk downloading risked triggering Qobuz's security thresholds (rate limiting) directly on the personal account, potentially leading to account bans.

2. The Modified Qobuz Logic (Current Fallback System)
With this update, the personal token acts as a "safety net" rather than the first choice. Here is the new flow:

"Anonymous" First Attempt: When searching for a track, the script initially ignores the personal token. It sends the request using only the public app_id and app_secret (acting as an unconfigured user).

Success? End of story: If the public API responds successfully (200 OK), the program fetches the data and proceeds. The user's personal account remains completely untouched.

Failure? Token Fallback Triggered: If Qobuz blocks the public request (returning a 400 or 401 error, usually because too many people are using the public keys), the code intercepts the error. It realizes "Plan A" failed and retries the exact same call, but this time enabling use_fallback_token=True.

The Rescue Call: During this second attempt, the personal token is finally injected into the X-User-Auth-Token header. Since it's a valid, unblocked account, the request succeeds and the download is saved.