### PR TITLE
fix(packaging): add missing pydantic dependency for PyPI module imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ classifiers = [
 dependencies = [
   "requests>=2.32.3",
   "mutagen>=1.47.0",
-  "pyotp>=2.9.0"
+  "pyotp>=2.9.0",
+  "pydantic>=2.7.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
### Motivation
- Corrigir o `ModuleNotFoundError` ao importar `SpotiFLAC` e garantir que o pacote declare a dependência runtime necessária, já que `SpotiFLAC/core/models.py` usa APIs do `pydantic` v2.

### Description
- Adicionado `pydantic>=2.7.0` em `project.dependencies` no `pyproject.toml` para alinhar as dependências do pacote com os imports usados no código.

### Testing
- Executados os checks automáticos: `python -m compileall -q SpotiFLAC launcher.py` (OK) e `python -m pip wheel . --no-deps --no-build-isolation -w dist` (OK — wheel criada), enquanto `python -m pip wheel . --no-deps` e `python -m pip install -q build pydantic` falharam devido a limitações de rede/proxy no ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6570228888325b827836b2b4926e7)