### PR TITLE
Handle lyrics fetch failures in FLAC tagger and add pydantic dependency

### DIFF
--- a/SpotiFLAC/core/tagger.py
+++ b/SpotiFLAC/core/tagger.py
@@ -51,14 +51,18 @@ def embed_metadata(
         tags = metadata.as_flac_tags(first_artist_only=first_artist_only)
         tags["DESCRIPTION"] = SOURCE_TAG
 
+        lyrics: str | None = None
         if embed_lyrics and metadata.title and metadata.first_artist:
             from .lyrics import fetch_lyrics
-            lyrics = fetch_lyrics(
-            metadata.title,
-            metadata.first_artist,
-            metadata.album,
-            metadata.duration_ms // 1000,
-            )
+            try:
+                lyrics = fetch_lyrics(
+                    metadata.title,
+                    metadata.first_artist,
+                    metadata.album,
+                    metadata.duration_ms // 1000,
+                )
+            except Exception as exc:
+                logger.warning("Lyrics fetch failed for %s: %s", path.name, exc)
         if lyrics:
             tags["LYRICS"] = lyrics
             logger.debug("Lyrics embedded: %s chars", len(lyrics))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ classifiers = [
 dependencies = [
   "requests>=2.32.3",
   "mutagen>=1.47.0",
-  "pyotp>=2.9.0"
+  "pyotp>=2.9.0",
+  "pydantic>=2.7.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
### Motivation
- Prevent failures in `embed_metadata` when `fetch_lyrics` raises an exception and ensure the package declares `pydantic` as a dependency.

### Description
- Wrap the call to `fetch_lyrics` in `embed_metadata` with a `try/except`, initialize `lyrics` ahead of time, and log a warning on failure so embedding proceeds without lyrics; and add `pydantic>=2.7.0` to `pyproject.toml` dependencies.

### Testing
- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6570228888325b827836b2b4926e7)