### PR TITLE
refactor to async

### DIFF
--- a/SpotiFLAC/__main__.py
+++ b/SpotiFLAC/__main__.py
@@ -1,0 +1,208 @@
+"""
+SpotiFLAC/__main__.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+from .client import AsyncSpotiFLAC
+from .launcher import (
+    _load_profile_into_defaults,
+    load_config,
+    parse_args,
+)
+from .core.ffmpeg_check import print_ffmpeg_warning
+
+
+async def _run_cli_download(args, merged_defaults: dict) -> None:
+    """Costruisce AsyncSpotiFLAC dagli argomenti CLI ed esegue il download."""
+    quality = args.quality or merged_defaults.get("quality", "LOSSLESS")
+    qobuz_local_api_url = args.qobuz_local_api_url or merged_defaults.get(
+        "qobuz_local_api_url"
+    )
+    tidal_custom_api = args.tidal_custom_api or merged_defaults.get("tidal_custom_api")
+    timeout_s = (
+        args.timeout_s if args.timeout_s is not None else merged_defaults.get("timeout_s")
+    )
+    track_max_retries = (
+        args.retries
+        if args.retries is not None
+        else merged_defaults.get("track_max_retries", 0)
+    )
+
+    log_level = logging.DEBUG if args.verbose else logging.WARNING
+    log_format = (
+        "%(levelname)s:%(name)s: %(message)s"
+        if args.verbose
+        else "%(levelname)s: %(message)s"
+    )
+    logging.basicConfig(level=log_level, format=log_format)
+
+    async with AsyncSpotiFLAC(
+        output_dir=args.output_dir,
+        services=args.service,
+        filename_format=args.filename_format,
+        use_track_numbers=args.use_track_numbers,
+        use_album_track_numbers=args.use_album_track_numbers,
+        use_artist_subfolders=args.use_artist_subfolders,
+        use_album_subfolders=args.use_album_subfolders,
+        allow_fallback=True,
+        quality=quality,
+        first_artist_only=args.first_artist_only,
+        include_featuring=args.include_featuring,
+        log_level=log_level,
+        output_path=args.output_path,
+        embed_lyrics=args.embed_lyrics,
+        lyrics_providers=args.lyrics_providers,
+        enrich_metadata=args.enrich,
+        enrich_providers=args.enrich_providers,
+        qobuz_local_api_url=qobuz_local_api_url,
+        tidal_custom_api=tidal_custom_api,
+        track_max_retries=track_max_retries,
+        post_download_action=args.post_action,
+        post_download_command=args.post_command,
+        timeout_s=timeout_s,
+    ) as client:
+        urls = args.url if isinstance(args.url, list) else [args.url]
+        await client.download_batch(urls, loop_minutes=args.loop)
+
+    if args.save_profile:
+        try:
+            from .core.profiles import save_profile_async
+
+            profile_cfg = {
+                "services": args.service,
+                "quality": quality,
+                "filename_format": args.filename_format,
+                "use_track_numbers": args.use_track_numbers,
+                "use_album_track_numbers": args.use_album_track_numbers,
+                "use_artist_subfolders": args.use_artist_subfolders,
+                "use_album_subfolders": args.use_album_subfolders,
+                "first_artist_only": args.first_artist_only,
+                "include_featuring": args.include_featuring,
+                "allow_fallback": True,
+                "embed_lyrics": args.embed_lyrics,
+                "lyrics_providers": args.lyrics_providers,
+                "enrich_metadata": args.enrich,
+                "enrich_providers": args.enrich_providers,
+                "track_max_retries": track_max_retries,
+                "post_download_action": args.post_action,
+                "post_download_command": args.post_command,
+                "qobuz_local_api_url": qobuz_local_api_url,
+                "tidal_custom_api": tidal_custom_api,
+                "timeout_s": timeout_s,
+                "loop": args.loop,
+            }
+            await save_profile_async(args.save_profile, profile_cfg)
+            print(f"[profile] Saved as: {args.save_profile}")
+        except Exception as exc:
+            print(f"[profile] Save error: {exc}")
+
+
+async def main() -> None:
+    """
+    Unico entry point asincrono del processo. Sostituisce `amain()` di
+    launcher.py: nessuna logica qui apre un proprio event loop separato,
+    tutto — check aggiornamenti, sync estensioni, GUI/interactive/CLI —
+    gira sull'unico loop avviato da `asyncio.run(main())` in fondo al file.
+    """
+    from .check_update import check_for_updates_async
+
+    try:
+        await check_for_updates_async()
+    except Exception:
+        pass
+
+    # GUI mode: la webview gestisce il proprio ciclo di eventi nativo (non
+    # asyncio) — resta un caso speciale sincrono, invariato rispetto a prima.
+    if "--gui" in sys.argv:
+        from .app import run_gui
+
+        run_gui()
+        return
+
+    if "--interactive" in sys.argv:
+        from .interactive import run_interactive
+
+        print_ffmpeg_warning()
+        cfg = await run_interactive()
+
+        log_level = logging.WARNING
+        logging.basicConfig(
+            level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+
+        async with AsyncSpotiFLAC(
+            output_dir=cfg["output_dir"],
+            services=cfg["services"],
+            filename_format=cfg["filename_format"],
+            use_track_numbers=cfg["use_track_numbers"],
+            use_album_track_numbers=cfg["use_album_track_numbers"],
+            use_artist_subfolders=cfg["use_artist_subfolders"],
+            use_album_subfolders=cfg["use_album_subfolders"],
+            quality=cfg["quality"],
+            first_artist_only=cfg["first_artist_only"],
+            include_featuring=cfg.get("include_featuring", False),
+            log_level=log_level,
+            output_path=cfg.get("output_path"),
+            allow_fallback=cfg.get("allow_fallback", True),
+            embed_lyrics=cfg["embed_lyrics"],
+            lyrics_providers=cfg["lyrics_providers"],
+            enrich_metadata=cfg["enrich_metadata"],
+            enrich_providers=cfg["enrich_providers"],
+            qobuz_local_api_url=cfg.get("qobuz_local_api_url"),
+            tidal_custom_api=cfg.get("tidal_custom_api") or None,
+            track_max_retries=cfg.get("track_max_retries", 0),
+            post_download_action=cfg.get("post_download_action", "none"),
+            post_download_command=cfg.get("post_download_command", ""),
+            timeout_s=cfg.get("timeout_s"),
+        ) as client:
+            await client.download_batch([cfg["url"]], loop_minutes=cfg.get("loop"))
+        return
+
+    if len(sys.argv) == 1:
+        import argparse
+
+        parser = argparse.ArgumentParser(prog="spotiflac")
+        parser.add_argument("--gui", action="store_true")
+        parser.add_argument("--interactive", action="store_true")
+        parser.print_help()
+        return
+
+    print_ffmpeg_warning()
+
+    profile_defaults: dict = {}
+    if "--profile" in sys.argv:
+        idx = sys.argv.index("--profile")
+        if idx + 1 < len(sys.argv):
+            profile_defaults = await _load_profile_into_defaults(sys.argv[idx + 1])
+
+    file_cfg = load_config()
+    merged_defaults = {**file_cfg, **profile_defaults}
+    args = parse_args(profile_defaults=merged_defaults)
+
+    if not args.url or not args.output_dir:
+        import argparse
+
+        parser = argparse.ArgumentParser(prog="spotiflac")
+        parser.add_argument("--gui", action="store_true")
+        parser.add_argument("--interactive", action="store_true")
+        parser.print_help()
+        return
+
+    await _run_cli_download(args, merged_defaults)
+
+
+def run() -> None:
+    """Punto d'ingresso sincrono (script console `spotiflac`)."""
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n\n[!] Operation interrupted by user.")
+
+
+if __name__ == "__main__":
+    run()

--- a/SpotiFLAC/client.py
+++ b/SpotiFLAC/client.py
@@ -1,0 +1,306 @@
+"""
+SpotiFLAC/client.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import TracebackType
+from typing import Any, Optional, Type
+
+from .core.http import NetworkManager
+from .core.models import TrackMetadata
+from .downloader import DownloadOptions, SpotiflacDownloader
+from .providers.spotify_metadata import SpotifyMetadataClient, parse_spotify_url
+
+logger = logging.getLogger("SpotiFLAC")
+
+
+def _setup_logger(level: int) -> logging.Logger:
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("[%(levelname)s] %(name)s: %(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger
+
+
+class AsyncSpotiFLAC:
+    """
+    Client asincrono nativo per SpotiFLAC.
+
+    Uso consigliato (garantisce chiusura pulita delle risorse HTTP):
+
+        async with AsyncSpotiFLAC(output_dir="./downloads") as client:
+            await client.download_track("https://open.spotify.com/track/...")
+            playlist_meta, tracks = await client.get_playlist("https://...")
+
+    Se usato senza context manager, ricordarsi di chiamare `await client.aclose()`.
+    """
+
+    def __init__(
+        self,
+        output_dir: str,
+        services: list[str] | None = None,
+        filename_format: str = "{title} - {artist}",
+        use_track_numbers: bool = False,
+        use_album_track_numbers: bool = False,
+        use_artist_subfolders: bool = False,
+        use_album_subfolders: bool = False,
+        allow_fallback: bool = True,
+        quality: str = "LOSSLESS",
+        first_artist_only: bool = False,
+        include_featuring: bool = False,
+        log_level: int = logging.WARNING,
+        output_path: str | None = None,
+        embed_lyrics: bool = True,
+        lyrics_providers: list[str] | None = None,
+        enrich_metadata: bool = True,
+        enrich_providers: list[str] | None = None,
+        qobuz_token: str | None = None,
+        qobuz_local_api_url: str | None = None,
+        track_max_retries: int = 0,
+        post_download_action: str = "none",
+        post_download_command: str = "",
+        tidal_custom_api: str | None = None,
+        timeout_s: int | None = None,
+        max_concurrent_downloads: int = 2,
+        sync_extensions: bool = True,
+    ) -> None:
+        self._logger = _setup_logger(log_level)
+        self._sync_extensions_on_enter = sync_extensions
+        self._entered = False
+
+        self._opts = DownloadOptions(
+            output_dir=output_dir,
+            services=services or ["tidal"],
+            filename_format=filename_format,
+            use_track_numbers=use_track_numbers,
+            use_album_track_numbers=use_album_track_numbers,
+            use_artist_subfolders=use_artist_subfolders,
+            use_album_subfolders=use_album_subfolders,
+            allow_fallback=allow_fallback,
+            quality=quality,
+            first_artist_only=first_artist_only,
+            include_featuring=include_featuring,
+            output_path=output_path,
+            embed_lyrics=embed_lyrics,
+            lyrics_providers=lyrics_providers
+            or ["spotify", "apple", "musixmatch", "lrclib", "amazon"],
+            enrich_metadata=enrich_metadata,
+            enrich_providers=enrich_providers
+            or ["deezer", "apple", "qobuz", "tidal", "soundcloud"],
+            qobuz_token=qobuz_token,
+            qobuz_local_api_url=qobuz_local_api_url,
+            track_max_retries=track_max_retries,
+            post_download_action=post_download_action,
+            post_download_command=post_download_command,
+            tidal_custom_api=tidal_custom_api,
+            timeout_s=timeout_s,
+            max_concurrent_downloads=max_concurrent_downloads,
+        )
+
+        self._downloader = SpotiflacDownloader(self._opts)
+        self._metadata_client: SpotifyMetadataClient | None = None
+
+    # ------------------------------------------------------------------
+    # Async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> "AsyncSpotiFLAC":
+        # Inizializza (lazy, ma esplicito qui) l'httpx.AsyncClient condiviso
+        # per l'event loop corrente. NetworkManager fa già connection
+        # pooling e dedup per-loop; chiamarlo qui dentro __aenter__ assicura
+        # che il client sia pronto PRIMA che qualunque provider lo usi,
+        # evitando la creazione lazy sparsa nel primo metodo chiamato.
+        await NetworkManager.get_async_client_safe()
+
+        if self._sync_extensions_on_enter:
+            try:
+                from .extensions.manager import ExtensionManager
+
+                await asyncio.to_thread(ExtensionManager, auto_install_downloads=True)
+            except Exception as exc:
+                self._logger.warning("[client] Extension sync skipped: %s", exc)
+
+        self._entered = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Chiude il client HTTP condiviso legato all'event loop corrente."""
+        await NetworkManager.aclose_loop_client()
+        self._entered = False
+
+    # ------------------------------------------------------------------
+    # API asincrona pubblica
+    # ------------------------------------------------------------------
+
+    async def download_track(
+        self, url: str, *, loop_minutes: int | None = None
+    ) -> list[TrackMetadata]:
+        """
+        Scarica una singola URL (track/album/playlist/artista/URL nativo di
+        un altro provider). Restituisce le eventuali tracce fallite
+        (per un'eventuale retry manuale da parte del chiamante).
+        """
+        self._ensure_entered()
+        return await self._downloader._run_once_async(url)
+
+    async def download_batch(
+        self, urls: list[str], *, loop_minutes: int | None = None
+    ) -> None:
+        """Scarica una lista di URL in sequenza, con loop di retry opzionale."""
+        self._ensure_entered()
+        await self._downloader.run_async(urls, loop_minutes=loop_minutes)
+
+    async def get_playlist(self, url: str) -> tuple[dict, list[TrackMetadata]]:
+        """
+        Recupera solo i metadati di una playlist/album/artista, senza
+        scaricare nulla. Utile per costruire UI o code di lavoro custom.
+        """
+        self._ensure_entered()
+        collection_name, tracks, info = await self._downloader._resolve_metadata_async(
+            url
+        )
+        return {"name": collection_name, **info}, tracks
+
+    async def get_track_metadata(self, url_or_id: str) -> TrackMetadata:
+        """Recupera i metadati di una singola track Spotify."""
+        self._ensure_entered()
+        client = self._get_metadata_client()
+        if url_or_id.startswith("http") or url_or_id.startswith("spotify:"):
+            info = parse_spotify_url(url_or_id)
+            return await client.get_track_async(info["id"])
+        return await client.get_track_async(url_or_id)
+
+    async def search(self, query: str, limit: int = 20) -> dict[str, list]:
+        """Ricerca unificata (tracks/albums/artists/playlists) su Spotify."""
+        self._ensure_entered()
+        client = self._get_metadata_client()
+        return await client.search_async(query, limit=limit)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_metadata_client(self) -> SpotifyMetadataClient:
+        if self._metadata_client is None:
+            self._metadata_client = SpotifyMetadataClient()
+        return self._metadata_client
+
+    def _ensure_entered(self) -> None:
+        if not self._entered:
+            # Non è un errore bloccante: NetworkManager crea comunque il
+            # client lazy alla prima richiesta. Segnaliamo solo che l'uso
+            # raccomandato è tramite `async with AsyncSpotiFLAC(...) as c:`
+            # per garantire cleanup deterministico delle connessioni.
+            self._logger.debug(
+                "[client] AsyncSpotiFLAC used outside of 'async with' — "
+                "resources will not be closed automatically."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Wrapper sincrono retrocompatibile
+# ---------------------------------------------------------------------------
+
+
+def SpotiFLAC(
+    url: str | list[str],
+    output_dir: str,
+    services: list[str] | None = None,
+    filename_format: str = "{title} - {artist}",
+    use_track_numbers: bool = False,
+    use_album_track_numbers: bool = False,
+    use_artist_subfolders: bool = False,
+    use_album_subfolders: bool = False,
+    loop: int | None = None,
+    allow_fallback: bool = True,
+    quality: str = "LOSSLESS",
+    first_artist_only: bool = False,
+    include_featuring: bool = False,
+    log_level: int = logging.WARNING,
+    output_path: str | None = None,
+    embed_lyrics: bool = True,
+    lyrics_providers: list[str] | None = None,
+    enrich_metadata: bool = True,
+    enrich_providers: list[str] | None = None,
+    qobuz_token: str | None = None,
+    qobuz_local_api_url: str | None = None,
+    track_max_retries: int = 0,
+    post_download_action: str = "none",
+    post_download_command: str = "",
+    tidal_custom_api: str | None = None,
+    timeout_s: int | None = None,
+    max_concurrent_downloads: int = 2,
+    sync_extensions: bool = True,
+) -> None:
+    """
+    Wrapper SINCRONO retrocompatibile.
+
+    Firma e comportamento osservabile identici alla vecchia `SpotiFLAC()`:
+    chi la chiama da codice sincrono (script, notebook, bot Telegram non
+    async, ecc.) non deve cambiare nulla. Internamente istanzia
+    `AsyncSpotiFLAC` e la esegue con `asyncio.run()`, quindi apre/chiude
+    UN SOLO event loop per l'intera chiamata — niente più
+    "un event loop per thread".
+
+    Se sei già dentro un contesto async, usa direttamente `AsyncSpotiFLAC`
+    con `async with`; chiamare questo wrapper da dentro un event loop già
+    attivo (es. Jupyter, un altro `async def`) solleverebbe
+    "asyncio.run() cannot be called from a running event loop" — in quel
+    caso, semplicemente `await`a `AsyncSpotiFLAC` direttamente.
+    """
+
+    async def _run() -> None:
+        async with AsyncSpotiFLAC(
+            output_dir=output_dir,
+            services=services,
+            filename_format=filename_format,
+            use_track_numbers=use_track_numbers,
+            use_album_track_numbers=use_album_track_numbers,
+            use_artist_subfolders=use_artist_subfolders,
+            use_album_subfolders=use_album_subfolders,
+            allow_fallback=allow_fallback,
+            quality=quality,
+            first_artist_only=first_artist_only,
+            include_featuring=include_featuring,
+            log_level=log_level,
+            output_path=output_path,
+            embed_lyrics=embed_lyrics,
+            lyrics_providers=lyrics_providers,
+            enrich_metadata=enrich_metadata,
+            enrich_providers=enrich_providers,
+            qobuz_token=qobuz_token,
+            qobuz_local_api_url=qobuz_local_api_url,
+            track_max_retries=track_max_retries,
+            post_download_action=post_download_action,
+            post_download_command=post_download_command,
+            tidal_custom_api=tidal_custom_api,
+            timeout_s=timeout_s,
+            max_concurrent_downloads=max_concurrent_downloads,
+            sync_extensions=sync_extensions,
+        ) as client:
+            await client.download_batch(
+                [url] if isinstance(url, str) else list(url),
+                loop_minutes=loop,
+            )
+
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt:
+        print("\n\n[!] Operation interrupted by user.")
+    except Exception as e:
+        logger.error("Critical error during execution: %s", e)
+
+
+__all__ = ["AsyncSpotiFLAC", "SpotiFLAC"]

--- a/SpotiFLAC/core/progress.py
+++ b/SpotiFLAC/core/progress.py
@@ -1,22 +1,22 @@
+"""
+progress.py — Async-native progress tracking
+"""
+
 from __future__ import annotations
 
 import asyncio
 import io
 import logging
 import sys
-import threading
 import time
-import queue as _queue
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-
 from tqdm import tqdm
 
-# Sincronizzazione visiva centralizzata sul core di tqdm.
-_CONSOLE_LOCK = threading.RLock()
-tqdm.set_lock(_CONSOLE_LOCK)
+# tqdm.get_lock() rimane come lock nativo di tqdm (non è un nostro accrocchio,
+# è la sincronizzazione interna della libreria per la scrittura su stderr).
 
 
 def safe_print(*args: object, **kwargs: Any) -> None:
@@ -34,28 +34,18 @@ class TqdmLoggingHandler(logging.Handler):
     def __init__(self) -> None:
         super().__init__()
         self._message_cache: dict[str, float] = {}
-        self._cache_ttl = 0.5  # 500ms deduplication window
+        self._cache_ttl = 0.5
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
             msg = self.format(record)
             now = time.time()
-
-            # Deduplication: skip if same message logged recently
-            if msg in self._message_cache:
-                if now - self._message_cache[msg] < self._cache_ttl:
-                    return
-
-            # Update cache and write
+            if msg in self._message_cache and now - self._message_cache[msg] < self._cache_ttl:
+                return
             self._message_cache[msg] = now
-
-            # Cleanup old entries (keep cache small)
             self._message_cache = {
-                k: v
-                for k, v in self._message_cache.items()
-                if now - v < self._cache_ttl * 2
+                k: v for k, v in self._message_cache.items() if now - v < self._cache_ttl * 2
             }
-
             with tqdm.get_lock():
                 tqdm.write(msg, file=sys.stderr)
         except Exception:
@@ -108,21 +98,19 @@ def install_console_interception() -> None:
         if isinstance(handler, logging.StreamHandler):
             root.removeHandler(handler)
 
-    # Some SpotiFLAC loggers may have their own StreamHandler attached,
-    # which would duplicate warnings and info messages along with the root handler.
-    for name, logger in list(logging.Logger.manager.loggerDict.items()):
-        if isinstance(logger, logging.Logger) and (
+    for name, logger_obj in list(logging.Logger.manager.loggerDict.items()):
+        if isinstance(logger_obj, logging.Logger) and (
             name == "SpotiFLAC" or name.startswith("SpotiFLAC.")
         ):
-            for handler in list(logger.handlers):
+            for handler in list(logger_obj.handlers):
                 if isinstance(handler, logging.StreamHandler):
-                    logger.removeHandler(handler)
-            logger.propagate = True
+                    logger_obj.removeHandler(handler)
+            logger_obj.propagate = True
 
     new_handler = TqdmLoggingHandler()
     new_handler.setFormatter(logging.Formatter("[%(levelname)s] %(name)s: %(message)s"))
-    new_handler.setLevel(root.level or logging.WARNING)
-    root.addHandler(new_handler)
+    new_handler.setLevel(logging.getLogger().level or logging.WARNING)
+    logging.getLogger().addHandler(new_handler)
 
 
 def uninstall_console_interception() -> None:
@@ -157,47 +145,21 @@ class DownloadItem:
     file_path: str = ""
 
 
-class _CrossLoopLock:
-    """
-    Adatta un threading.Lock (funziona correttamente attraverso PIÙ event
-    loop/thread, a differenza di asyncio.Lock che si lega permanentemente
-    al loop del thread che lo usa per primo) a un context manager
-    awaitable, senza mai bloccare l'event loop chiamante: prova ad
-    acquisire in modo non bloccante e, se occupato, cede il controllo con
-    asyncio.sleep() finché non si libera.
-
-    Necessario perché DownloadManager/DownloadBroadcaster sono singleton
-    globali usati da tracce scaricate in thread paralleli, ognuno col
-    proprio event loop (ogni thread fa il proprio asyncio.run()): un
-    asyncio.Lock creato la prima volta si legherebbe per sempre al loop
-    di quel primo thread, e ogni altro thread/loop che lo acquisisce
-    andrebbe in crash con "RuntimeError: ... is bound to a different
-    event loop" — lo stesso bug già visto e risolto per ProgressManager.
-    """
-
-    def __init__(self, poll_interval: float = 0.01):
-        self._lock = threading.Lock()
-        self._poll_interval = poll_interval
-
-    async def __aenter__(self):
-        while not self._lock.acquire(blocking=False):
-            await asyncio.sleep(self._poll_interval)
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        self._lock.release()
-        return False
-
-
 class DownloadBroadcaster:
-    _instance = None
+    """
+    Singleton per lo streaming degli eventi di progresso verso eventuali
+    listener esterni (es. la GUI webview). Prima usava _CrossLoopLock per
+    proteggere l'accesso a self._listeners da più thread/loop paralleli.
+    Con un unico event loop, asyncio.Lock() è sufficiente e corretto.
+    """
+
+    _instance: "DownloadBroadcaster | None" = None
 
     def __new__(cls) -> "DownloadBroadcaster":
-        # Removed _creation_lock: now thread-safe in single-thread asyncio context
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._listeners = set()
-            cls._instance._lock = _CrossLoopLock()
+            cls._instance._lock = asyncio.Lock()
             cls._instance._last_broadcast_time = 0.0
         return cls._instance
 
@@ -229,25 +191,27 @@ class DownloadBroadcaster:
 
 
 class DownloadManager:
+    """
+    Singleton che tiene lo stato della coda di download.
+    _CrossLoopLock -> asyncio.Lock(): valido perché non esistono più event
+    loop multipli concorrenti (nessun thread fa più il proprio asyncio.run()).
+    """
+
     _instance: "DownloadManager | None" = None
-    _creation_lock = threading.Lock()
 
     def __new__(cls) -> "DownloadManager":
-        with cls._creation_lock:
-            if cls._instance is None:
-                inst = super().__new__(cls)
-                inst._init_state()
-                cls._instance = inst
+        if cls._instance is None:
+            inst = super().__new__(cls)
+            inst._init_state()
+            cls._instance = inst
         return cls._instance
 
     def _init_state(self) -> None:
-        self._lock = _CrossLoopLock()
+        self._lock = asyncio.Lock()
         self._queue: list[DownloadItem] = []
         self.total_downloaded = 0.0
         self.current_item_id = ""
         self.session_start = 0.0
-
-    # Rimosse le properties is_downloading e current_speed per evitare accessi fuori lock/deadlock.
 
     async def add_to_queue(
         self,
@@ -346,7 +310,6 @@ class DownloadManager:
         await DownloadBroadcaster().broadcast_immediate(stats)
 
     async def get_item_speed(self, item_id: str) -> float:
-        """Safe method to get speed without direct queue access from the callback."""
         async with self._lock:
             for item in self._queue:
                 if item.id == item_id:
@@ -382,7 +345,6 @@ class DownloadManager:
                 }
                 queue_items.append(item_data)
 
-                # Statistiche calcolate in-place per evitare deadlock o chiamate incoerenti
                 if i.status == DownloadStatus.DOWNLOADING:
                     is_downloading = True
                     current_speed += i.speed
@@ -424,71 +386,61 @@ class DownloadManager:
 
 
 class ProgressManager:
+    """
+    Gestisce le barre tqdm per-track.
+
+    Prima: queue.Queue (thread-safe nativa) + threading.Thread consumer,
+    necessari perché ogni download girava nel proprio thread/event loop.
+
+    Ora: asyncio.Queue() + asyncio.Task consumer. Un solo event loop, quindi
+    niente più bisogno di primitive thread-safe: enqueue_progress() è una
+    semplice put_nowait() sulla queue asyncio (safe da qualunque coroutine
+    o callback sincrono chiamato all'interno dello stesso loop).
+    """
+
     _bars: dict[str, tqdm] = {}
     _slot_map: dict[str, int] = {}
     _master_bar: tqdm | None = None
     _master_enabled: bool = False
 
-    # queue.Queue (thread-safe nativa) invece di asyncio.Queue: non ha
-    # alcun concetto di "event loop di appartenenza", quindi funziona
-    # correttamente anche con più thread paralleli che girano ognuno il
-    # proprio event loop (ogni thread di download fa il proprio
-    # asyncio.run()). Un asyncio.Queue creato durante il primo
-    # enqueue_progress() si legherebbe per sempre a quel loop specifico:
-    # ogni altro thread/loop che tenta un .put()/.get() va in crash con
-    # "RuntimeError: <Queue ...> is bound to a different event loop"
-    # (esattamente il traceback osservato).
-    _event_queue: "_queue.Queue | None" = None
-    _worker_thread: threading.Thread | None = None
-    _worker_lock = threading.Lock()
-    _stop_event: threading.Event | None = None
+    _event_queue: "asyncio.Queue | None" = None
+    _worker_task: "asyncio.Task | None" = None
+
+    # ------------------------------------------------------------------
+    # Worker lifecycle
+    # ------------------------------------------------------------------
 
     @classmethod
     def start_worker(cls) -> None:
         """
-        Avvia il thread consumer in modo idempotente e thread-safe.
-        Non è più una coroutine: un vero threading.Thread di sistema non
-        è legato a nessun event loop, quindi consuma eventi inseriti da
-        QUALUNQUE thread/loop senza mai incappare nel problema sopra.
+        Avvia il task consumer in modo idempotente. Deve essere chiamato da
+        dentro l'event loop attivo (create_task lo richiede).
         """
-        with cls._worker_lock:
-            if cls._event_queue is None:
-                cls._event_queue = _queue.Queue()
-            if cls._stop_event is None:
-                cls._stop_event = threading.Event()
+        if cls._event_queue is None:
+            cls._event_queue = asyncio.Queue()
 
-            if cls._worker_thread is not None and cls._worker_thread.is_alive():
-                return
+        if cls._worker_task is not None and not cls._worker_task.done():
+            return
 
-            cls._stop_event.clear()
-            cls._worker_thread = threading.Thread(
-                target=cls._process_events_sync, daemon=True
-            )
-            cls._worker_thread.start()
+        cls._worker_task = asyncio.create_task(cls._process_events_async())
 
     @classmethod
     async def stop_worker(cls) -> None:
-        if cls._worker_thread is not None:
-            if cls._stop_event is not None:
-                cls._stop_event.set()
+        if cls._worker_task is not None:
             if cls._event_queue is not None:
-                # sblocca il .get() bloccante nel thread consumer
-                try:
-                    cls._event_queue.put_nowait(None)
-                except Exception:
-                    pass
-            cls._worker_thread.join(timeout=5)
-            cls._worker_thread = None
+                # sblocca il .get() in attesa nel task consumer
+                await cls._event_queue.put(None)
+            try:
+                await asyncio.wait_for(cls._worker_task, timeout=5)
+            except asyncio.TimeoutError:
+                cls._worker_task.cancel()
+            cls._worker_task = None
 
     @classmethod
-    def _process_events_sync(cls) -> None:
+    async def _process_events_async(cls) -> None:
         assert cls._event_queue is not None
-        while not (cls._stop_event and cls._stop_event.is_set()):
-            try:
-                event = cls._event_queue.get()
-            except Exception:
-                break
-
+        while True:
+            event = await cls._event_queue.get()
             if event is None:
                 break
 
@@ -514,17 +466,16 @@ class ProgressManager:
                     if total_bytes is not None and current_bytes >= total_bytes:
                         cls.release_bar(item_id)
             except Exception:
-                logging.getLogger(__name__).exception(
-                    "ProgressManager consumer crashed"
-                )
+                logging.getLogger(__name__).exception("ProgressManager consumer crashed")
 
     @classmethod
     def enqueue_progress(
         cls, item_id: str, track_name: str, current_bytes: int, total_bytes: int | None
     ) -> None:
         """
-        Ora sincrona: un put su queue.Queue è già non bloccante e
-        thread-safe, non serve alcun event loop né `await`.
+        Chiamata da coroutine/callback dentro il loop principale. Va avviato
+        il worker lazy la prima volta (idempotente) e poi si fa una semplice
+        put_nowait() — nessuna primitiva thread-safe necessaria.
         """
         cls.start_worker()
         if cls._event_queue is not None:
@@ -535,16 +486,18 @@ class ProgressManager:
             except Exception:
                 pass
 
+    # ------------------------------------------------------------------
+    # Bar management (sync, invariato — protetto da tqdm.get_lock())
+    # ------------------------------------------------------------------
+
     @classmethod
     def _allocate_slot(cls, item_id: str) -> int:
         if item_id in cls._slot_map:
             return cls._slot_map[item_id]
-
         used_slots = set(cls._slot_map.values())
         slot = 0
         while slot in used_slots:
             slot += 1
-
         cls._slot_map[item_id] = slot
         return slot
 
@@ -585,7 +538,6 @@ class ProgressManager:
         if bar is None:
             cls._slot_map.pop(item_id, None)
             return
-
         try:
             bar.clear()
             bar.close()
@@ -615,7 +567,6 @@ class ProgressManager:
             raise ValueError(
                 "Only top-aligned master bar is supported by ProgressManager at this time."
             )
-
         with tqdm.get_lock():
             cls.clear_master_bar()
             cls._master_enabled = True
@@ -635,7 +586,6 @@ class ProgressManager:
             if cls._master_bar is None:
                 cls._master_enabled = False
                 return
-
             try:
                 cls._master_bar.clear()
                 cls._master_bar.close()
@@ -649,7 +599,6 @@ class ProgressManager:
         with tqdm.get_lock():
             if cls._master_bar is None:
                 return
-
             cls._master_bar.update(step)
             cls._master_bar.refresh()
 
@@ -658,20 +607,20 @@ class ProgressManager:
         with tqdm.get_lock():
             if cls._master_bar is None:
                 return
-
             cls._master_bar.reset(total=total_items)
             cls._master_bar.refresh()
 
 
 class ProgressCallback:
-    _bytes_since_refresh: int
-    _last_refresh_time: float
-    _last_reported_bytes: int
+    """
+    Callback di progresso passato ai provider. Invariato nella logica di
+    throttling; enqueue_progress() ora è thread-agnostic per costruzione
+    (asyncio.Queue), quindi resta sincrona e non-bloccante come prima.
+    """
 
     def __init__(self, item_id: str = "", track_name: str = "") -> None:
         self._item_id = item_id
         self._track_name = track_name
-        self._bytes_since_refresh = 0
         self._last_refresh_time = 0.0
         self._last_reported_bytes = 0
 
@@ -679,9 +628,6 @@ class ProgressCallback:
         now = time.time()
         is_final = bool(total_bytes and current_bytes >= total_bytes)
 
-        # Miglioria prestazionale critica: Throttling a monte.
-        # Ignore the update if at least 100ms have not passed and it is not the final piece,
-        # preventing event loop congestion with tens of thousands of tasks.
         if (
             not is_final
             and self._last_refresh_time > 0
@@ -692,8 +638,6 @@ class ProgressCallback:
         current_bytes = max(0, current_bytes)
         total_bytes = total_bytes if total_bytes > 0 else None
 
-        # enqueue_progress ora è sincrona (queue.Queue thread-safe):
-        # l'inserimento è istantaneo, non serve più asyncio.create_task.
         ProgressManager.enqueue_progress(
             self._item_id, self._track_name, current_bytes, total_bytes
         )
@@ -711,7 +655,6 @@ class ProgressCallback:
             self._last_refresh_time = now
             self._last_reported_bytes = current_bytes
 
-        # Fire-and-forget del manager per non ritardare il download
         asyncio.create_task(
             DownloadManager().update_progress(
                 self._item_id, current_mb, total_mb, speed_mbps

--- a/SpotiFLAC/core/signed_session.py
+++ b/SpotiFLAC/core/signed_session.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 import hashlib
 import hmac
-import threading
 import json
 import logging
 import os
@@ -1001,57 +1000,32 @@ class SignedSessionClient:
                 self._client = None
 
 
-_AUTH_THREAD_LOCKS: dict[str, threading.Lock] = {}
-_AUTH_THREAD_LOCKS_GUARD = threading.Lock()
+# --- Fase 4: sincronizzazione dell'autenticazione (async-native) --------
+#
+# PRIMA: SpotiFLAC scaricava più tracce in parallelo tramite un
+# ThreadPoolExecutor dove ogni thread eseguiva il proprio asyncio.run()
+# (quindi ogni thread aveva un event loop DIVERSO). Un asyncio.Lock keyed
+# per (loop, namespace) non basta in quel caso: due thread paralleli, ognuno
+# col proprio loop, otterrebbero ciascuno un lock "vergine" e non si
+# sincronizzerebbero affatto — da qui l'accrocchio _AsyncThreadLockCtx che
+# avvolgeva un threading.Lock con polling asincrono.
+#
+# ORA: con un solo processo/thread e un solo event loop condiviso (nessun
+# download avvia più il proprio asyncio.run()), un dict di asyncio.Lock()
+# indicizzato per namespace è sufficiente e corretto: tutte le coroutine
+# "in gara" per autenticare lo stesso namespace girano sullo stesso loop,
+# quindi asyncio.Lock le serializza nativamente senza bisogno di polling
+# né di primitive thread-safe.
+_AUTH_LOCKS: dict[str, asyncio.Lock] = {}
 
 
-def _get_auth_thread_lock(namespace: str) -> threading.Lock:
-    """
-    Lock condiviso per namespace attraverso TUTTI i thread ed event loop
-    del processo — non solo all'interno dello stesso loop asyncio.
-
-    PERCHÉ QUESTO CAMBIO: SpotiFLAC scarica più tracce in parallelo tramite
-    un ThreadPoolExecutor, dove ogni thread esegue il proprio asyncio.run()
-    (quindi ogni thread ha un event loop DIVERSO). Il vecchio _AUTH_LOCKS
-    era un asyncio.Lock keyed by (loop, namespace): funziona solo tra
-    coroutine sullo STESSO loop. Due thread paralleli, ognuno col proprio
-    loop, ottenevano ciascuno un asyncio.Lock "vergine" e quindi NON si
-    sincronizzavano affatto — risultato osservato: due finestre Chrome
-    aperte in parallelo per la stessa autenticazione, con due challenge_id
-    diversi, e la seconda che fallisce a catturare il grant in tempo.
-    """
-    with _AUTH_THREAD_LOCKS_GUARD:
-        lock = _AUTH_THREAD_LOCKS.get(namespace)
-        if lock is None:
-            lock = threading.Lock()
-            _AUTH_THREAD_LOCKS[namespace] = lock
-        return lock
-
-
-class _AsyncThreadLockCtx:
-    """
-    Adatta un threading.Lock (sincronizzazione cross-thread/cross-loop) a
-    un context manager awaitable, senza mai bloccare l'event loop: prova
-    ad acquisire in modo non bloccante e, se occupato, cede il controllo
-    con asyncio.sleep() finché non si libera.
-    """
-
-    def __init__(self, lock: threading.Lock, poll_interval: float = 0.1):
-        self._lock = lock
-        self._poll_interval = poll_interval
-
-    async def __aenter__(self):
-        while not self._lock.acquire(blocking=False):
-            await asyncio.sleep(self._poll_interval)
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        self._lock.release()
-        return False
-
-
-def _get_auth_lock(namespace: str) -> "_AsyncThreadLockCtx":
-    return _AsyncThreadLockCtx(_get_auth_thread_lock(namespace))
+def _get_auth_lock(namespace: str) -> asyncio.Lock:
+    """Restituisce (creandolo se assente) l'asyncio.Lock per il namespace."""
+    lock = _AUTH_LOCKS.get(namespace)
+    if lock is None:
+        lock = asyncio.Lock()
+        _AUTH_LOCKS[namespace] = lock
+    return lock
 
 
 async def perform_signed_fetch(

--- a/SpotiFLAC/downloader.py
+++ b/SpotiFLAC/downloader.py
@@ -76,6 +76,11 @@ class DownloadOptions:
     timeout_s: int | None = None
     auto_pair_extensions: bool = True
     ext_dir: str | None = None
+    # Fase 2: numero massimo di download concorrenti gestiti dal semaforo
+    # asyncio.Semaphore in DownloadWorker._run_downloads_async(). Prima era
+    # una costante hardcoded (MAX_CONCURRENT_DOWNLOADS = 2) — ora è
+    # configurabile dal chiamante (CLI/API), mantenendo lo stesso default.
+    max_concurrent_downloads: int = 2
 
 
 def _build_provider(name: str, opts: DownloadOptions) -> BaseProvider | None:
@@ -411,59 +416,87 @@ class DownloadWorker:
         base_out: str,
         start: float,
     ) -> list[tuple[str, str, str]]:
-        MAX_CONCURRENT_DOWNLOADS = 2
-        semaphore = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS)
+        """
+        Fase 2 — concorrenza nativa asyncio.
 
-        async def worker_task(i: int, track: TrackMetadata):
+        Prima: una lista di asyncio.Task consumata con asyncio.as_completed().
+        Funzionalmente corretto, ma senza propagazione strutturata degli
+        errori (un task che solleva un'eccezione non attesa non annullava
+        gli altri, e la cancellazione andava gestita a mano).
+
+        Ora: asyncio.TaskGroup (structured concurrency, PEP 654/3.11+).
+        Il rate-limiting resta un asyncio.Semaphore(max_concurrent_downloads)
+        acquisito da ogni worker prima di fare I/O pesante (richieste di
+        rete / scrittura su disco). I risultati vengono processati man mano
+        che arrivano tramite una asyncio.Queue interna, così l'aggiornamento
+        della progress bar resta "a mano a mano" come nella versione con
+        as_completed, ma dentro un TaskGroup che garantisce: se un worker
+        solleva un'eccezione realmente inattesa, tutti gli altri task del
+        gruppo vengono cancellati in modo pulito invece di proseguire
+        silenziosamente.
+        """
+        max_concurrent = max(1, getattr(self._opts, "max_concurrent_downloads", 2))
+        semaphore = asyncio.Semaphore(max_concurrent)
+        results_queue: asyncio.Queue[
+            tuple[TrackMetadata, "object"] | None
+        ] = asyncio.Queue()
+
+        async def download_worker(i: int, track: TrackMetadata) -> None:
             position = i + 1
-            print_track_header(position, total, track.title, track.artists, track.album)
-            await manager.start_download(track.id)
-
-            out_dir = await self._track_output_dir_async(base_out, track)
-            result = await download_one_async(
-                track,
-                out_dir,
-                self._providers,
-                self._opts,
-                position,
-                self._is_album,
-            )
-            return track, result
-
-        async def limited_worker(i: int, track: TrackMetadata):
             async with semaphore:
-                return await worker_task(i, track)
-
-        tasks = [
-            asyncio.create_task(limited_worker(i, track))
-            for i, track in enumerate(self._tracks)
-        ]
-
-        for coro in asyncio.as_completed(tasks):
-            track, result = await coro
-            if result.success and result.skipped:
-                await manager.skip_download(track.id)
-            elif result.success:
-                size_mb = await _get_file_size_mb_async(result.file_path)
-                await manager.complete_download(
-                    track.id, result.file_path or "", size_mb
+                print_track_header(
+                    position, total, track.title, track.artists, track.album
                 )
-            else:
-                err = result.error or "unknown"
-                self._failed.append((track.id, track.title, track.artists, err))
-                safe_tqdm_write(
-                    f"\n  ✗  Failed: {track.title} — {track.artists}: {err}",
-                    file=sys.stderr,
-                )
-                logger.debug(
-                    "[worker] Failed: %s — %s: %s", track.title, track.artists, err
-                )
-                await manager.fail_download(track.id, err)
-                from .core.progress import ProgressCallback
+                await manager.start_download(track.id)
 
-                ProgressCallback.clear_item(track.id)
+                out_dir = await self._track_output_dir_async(base_out, track)
+                try:
+                    result = await download_one_async(
+                        track,
+                        out_dir,
+                        self._providers,
+                        self._opts,
+                        position,
+                        self._is_album,
+                    )
+                except Exception as exc:  # noqa: BLE001 — isoliamo il worker
+                    logger.exception(
+                        "[worker] Unexpected exception downloading '%s'", track.title
+                    )
+                    result = DownloadResult.fail("none", f"Unexpected error: {exc}")
 
-            ProgressManager.increment_master()
+            await results_queue.put((track, result))
+
+        async def consume_results() -> None:
+            for _ in range(total):
+                track, result = await results_queue.get()
+
+                if result.success and result.skipped:
+                    await manager.skip_download(track.id)
+                elif result.success:
+                    size_mb = await _get_file_size_mb_async(result.file_path)
+                    await manager.complete_download(
+                        track.id, result.file_path or "", size_mb
+                    )
+                else:
+                    err = result.error or "unknown"
+                    self._failed.append((track.id, track.title, track.artists, err))
+                    safe_tqdm_write(
+                        f"\n  ✗  Failed: {track.title} — {track.artists}: {err}",
+                        file=sys.stderr,
+                    )
+                    logger.debug(
+                        "[worker] Failed: %s — %s: %s", track.title, track.artists, err
+                    )
+                    await manager.fail_download(track.id, err)
+                    ProgressCallback.clear_item(track.id)
+
+                ProgressManager.increment_master()
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(consume_results())
+            for i, track in enumerate(self._tracks):
+                tg.create_task(download_worker(i, track))
 
         elapsed = time.perf_counter() - start
         self._print_summary(elapsed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SpotiFLAC"
-version = "1.3.8"
+version = "1.3.9"
 description = "Get Spotify tracks in true FLAC from Tidal, Qobuz & Amazon Music — no account required."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
refactor: migrate architecture to 100% async-native

- client: introduce `AsyncSpotiFLAC` as an async context manager with a shared httpx.AsyncClient. Retain `SpotiFLAC` as a backwards-compatible synchronous wrapper.
- downloader: remove `ThreadPoolExecutor`. Concurrency is now handled natively via `asyncio.TaskGroup` and rate-limited by `asyncio.Semaphore`.
- progress/manager: remove threads, `queue.Queue`, and custom cross-loop locks. The download queue and tqdm tasks now run entirely on `asyncio.Queue` and `asyncio.create_task`.
- signed_session: remove `_AsyncThreadLockCtx`. Turnstile authentication synchronization is now simplified using a standard global `asyncio.Lock`.
- main: run CLI entry point on a single unified event loop (`asyncio.run`), completely eliminating the overhead and cross-loop crashes caused by the previous multi-threading approach.

This update eliminates thread bottlenecks, resolves "bound to a different event loop" crashes, and drastically reduces CPU and RAM footprint during bulk downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added synchronous and asynchronous interfaces for downloads, metadata retrieval, and Spotify search.
  - Added configurable track retries, concurrent downloads, and post-download actions such as moving files or running commands.
  - Added profile-based CLI defaults and optional saving of effective profiles.
- **Bug Fixes**
  - Improved download error handling, retry behavior, and cleanup after interruptions.
  - Improved progress display and logging during concurrent downloads.
- **Chores**
  - Updated the application version to 1.3.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->