### PR TITLE
fix: close provider pools when a download batch finishes

### DIFF
--- a/SpotiFLAC/downloader.py
+++ b/SpotiFLAC/downloader.py
@@ -425,8 +425,6 @@ class DownloadWorker:
         return result
 
     def _close_providers(self) -> None:
-        """Release resources held by this run's providers (e.g. pooled
-        Node.js extension runtimes), so nothing outlives a single batch."""
         for provider in self._providers:
             close = getattr(provider, "close", None)
             if callable(close):
@@ -434,21 +432,23 @@ class DownloadWorker:
                     close()
 
     async def run_async(self) -> list[tuple[str, str, str]]:
-        manager = DownloadManager()
-        await manager.reset()
-        total = len(self._tracks)
-        start = time.perf_counter()
-
-        # Native async folder I/O delegation
-        base_out = await self._resolve_output_dir_async()
-
-        install_console_interception()
-        ProgressManager.initialize_master_bar(total, description="Progress")
         try:
-            return await self._run_downloads_async(manager, total, base_out, start)
+            manager = DownloadManager()
+            await manager.reset()
+            total = len(self._tracks)
+            start = time.perf_counter()
+
+            # Native async folder I/O delegation
+            base_out = await self._resolve_output_dir_async()
+
+            install_console_interception()
+            ProgressManager.initialize_master_bar(total, description="Progress")
+            try:
+                return await self._run_downloads_async(manager, total, base_out, start)
+            finally:
+                await ProgressManager.clear_all()
+                uninstall_console_interception()
         finally:
-            await ProgressManager.clear_all()
-            uninstall_console_interception()
             self._close_providers()
 
     async def _run_downloads_async(
@@ -557,6 +557,7 @@ class DownloadWorker:
             for t in worker_tasks:
                 if not t.done():
                     t.cancel()
+            await asyncio.gather(consumer_task, *worker_tasks, return_exceptions=True)
             raise
 
         elapsed = time.perf_counter() - start

--- a/SpotiFLAC/downloader.py
+++ b/SpotiFLAC/downloader.py
@@ -424,6 +424,15 @@ class DownloadWorker:
             raise ValueError(msg)
         return result
 
+    def _close_providers(self) -> None:
+        """Release resources held by this run's providers (e.g. pooled
+        Node.js extension runtimes), so nothing outlives a single batch."""
+        for provider in self._providers:
+            close = getattr(provider, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):
+                    close()
+
     async def run_async(self) -> list[tuple[str, str, str]]:
         manager = DownloadManager()
         await manager.reset()
@@ -440,6 +449,7 @@ class DownloadWorker:
         finally:
             await ProgressManager.clear_all()
             uninstall_console_interception()
+            self._close_providers()
 
     async def _run_downloads_async(
         self,

--- a/tests/test_download_worker_provider_cleanup.py
+++ b/tests/test_download_worker_provider_cleanup.py
@@ -1,4 +1,7 @@
 import asyncio
+from unittest.mock import patch
+
+import pytest
 
 from SpotiFLAC.downloader import DownloadOptions, DownloadWorker
 
@@ -15,20 +18,21 @@ class DummyProvider:
 
 def test_run_async_closes_providers_on_success(tmp_path) -> None:
     opts = DownloadOptions(output_dir=str(tmp_path))
-    worker = DownloadWorker(tracks=[], opts=opts)
     dummy = DummyProvider()
-    worker._providers = [dummy]
 
-    asyncio.run(worker.run_async())
+    with patch.object(DownloadWorker, "_build_providers", return_value=[dummy]):
+        worker = DownloadWorker(tracks=[], opts=opts)
+        asyncio.run(worker.run_async())
 
     assert dummy.closed
 
 
 def test_run_async_closes_providers_on_exception(tmp_path) -> None:
     opts = DownloadOptions(output_dir=str(tmp_path))
-    worker = DownloadWorker(tracks=[], opts=opts)
     dummy = DummyProvider()
-    worker._providers = [dummy]
+
+    with patch.object(DownloadWorker, "_build_providers", return_value=[dummy]):
+        worker = DownloadWorker(tracks=[], opts=opts)
 
     async def boom(*_args, **_kwargs):
         raise RuntimeError("boom")

--- a/tests/test_download_worker_provider_cleanup.py
+++ b/tests/test_download_worker_provider_cleanup.py
@@ -35,9 +35,7 @@ def test_run_async_closes_providers_on_exception(tmp_path) -> None:
 
     worker._run_downloads_async = boom
 
-    try:
+    with pytest.raises(RuntimeError, match="boom"):
         asyncio.run(worker.run_async())
-    except RuntimeError:
-        pass
 
     assert dummy.closed

--- a/tests/test_download_worker_provider_cleanup.py
+++ b/tests/test_download_worker_provider_cleanup.py
@@ -1,0 +1,43 @@
+import asyncio
+
+from SpotiFLAC.downloader import DownloadOptions, DownloadWorker
+
+
+class DummyProvider:
+    name = "dummy"
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_run_async_closes_providers_on_success(tmp_path) -> None:
+    opts = DownloadOptions(output_dir=str(tmp_path))
+    worker = DownloadWorker(tracks=[], opts=opts)
+    dummy = DummyProvider()
+    worker._providers = [dummy]
+
+    asyncio.run(worker.run_async())
+
+    assert dummy.closed
+
+
+def test_run_async_closes_providers_on_exception(tmp_path) -> None:
+    opts = DownloadOptions(output_dir=str(tmp_path))
+    worker = DownloadWorker(tracks=[], opts=opts)
+    dummy = DummyProvider()
+    worker._providers = [dummy]
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    worker._run_downloads_async = boom
+
+    try:
+        asyncio.run(worker.run_async())
+    except RuntimeError:
+        pass
+
+    assert dummy.closed


### PR DESCRIPTION
## What
DownloadWorker.run_async() builds a provider pool per batch but never
closes it. Extension-based providers (deezer, tidal-web) each hold a
pool of Node.js processes — Pool.close() already exists in
extensions/provider.py, it just had no caller.

## Impact
Every run_async() call leaks its provider pool's Node processes. In a
long-running service calling SpotiFLAC repeatedly, this accumulates
until the host runs out of resources. Seen in the wild: 55+ orphaned
_bridge.js processes, system load past 100.

## Fix
Adds DownloadWorker._close_providers(), called from run_async()'s
existing finally block (covers both success and failure).

## Testing
New tests cover the success and exception paths. Full suite passes
locally (150/150).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured download providers are properly closed after downloads complete.
  * Provider cleanup now also runs when download processing encounters an error.
  * Cleanup errors are safely suppressed to avoid disrupting download handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->