### PR TITLE
1.6.8

### DIFF
--- a/SpotiFLAC/core/models.py
+++ b/SpotiFLAC/core/models.py
@@ -84,7 +84,6 @@ class TrackMetadata(BaseModel):
         return self.artists.split(",")[0].strip()
 
     def as_flac_tags(self, *, first_artist_only: bool = False) -> dict[str, str]:
-        """Formatta i metadati come tag standard per file FLAC/Vorbis."""
         artist = self.first_artist if first_artist_only else self.artists
         album_artist = self.first_artist if first_artist_only else self.album_artist
 
@@ -109,8 +108,12 @@ class TrackMetadata(BaseModel):
         ]:
             if val:
                 tags[key] = val
-        return tags
 
+        if self.is_explicit:
+            tags["ITUNESADVISORY"] = "1"
+
+        return tags
+    
     def with_enrichment(self, extra: Any) -> TrackMetadata:
         """Returns una nuova istanza aggiornata con i dati dell'enrichment.
 

--- a/SpotiFLAC/core/solver.py
+++ b/SpotiFLAC/core/solver.py
@@ -32,6 +32,8 @@ _DEBUG_VISIBLE = os.environ.get("TS_DEBUG_VISIBLE", "").strip() == "1"
 
 
 _docker_flags = ["--no-sandbox", "--disable-dev-shm-usage"]
+_BROWSER_START_TIMEOUT_ENV = "TS_BROWSER_START_TIMEOUT"
+_DEFAULT_BROWSER_START_TIMEOUT_SECONDS = 30
 
 
 def _patch_nodriver_unknown_cdp_events() -> None:
@@ -353,6 +355,23 @@ def build_chromium_options(*, hidden: bool = True) -> ChromiumOptions:
     options = ChromiumOptions()
     options.binary_location = _find_chrome()
     options.headless = False
+
+    # pydoll uses a 10s default to verify the browser is alive after
+    # launching the renderer process. We expose the same contract via env and
+    # align the package's default with a 30s startup budget for Docker/CI, so
+    # browser startup isn't immediately killed by the upstream watchdog.
+    raw_start_timeout = os.environ.get(
+        _BROWSER_START_TIMEOUT_ENV,
+        str(_DEFAULT_BROWSER_START_TIMEOUT_SECONDS),
+    ).strip()
+    try:
+        start_timeout_seconds = int(raw_start_timeout)
+    except (TypeError, ValueError):
+        start_timeout_seconds = _DEFAULT_BROWSER_START_TIMEOUT_SECONDS
+    if start_timeout_seconds <= 0:
+        start_timeout_seconds = _DEFAULT_BROWSER_START_TIMEOUT_SECONDS
+    options.start_timeout = start_timeout_seconds
+
     profile_dir = _get_profile_dir()
     if os.path.exists(profile_dir):
         try:
@@ -387,6 +406,15 @@ def build_chromium_options(*, hidden: bool = True) -> ChromiumOptions:
         },
         "safebrowsing": {"enabled": True},
     }
+
+    logger.info(
+        "[solver] Chromium launch options prepared: binary=%s start_timeout=%ss profile_dir=%s hidden=%s debug_visible=%s",
+        options.binary_location,
+        options.start_timeout,
+        profile_dir,
+        hidden,
+        debug_visible,
+    )
 
     return options
 
@@ -446,6 +474,24 @@ async def _try_minimize_window(browser: Chrome) -> None:
         logger.debug("[solver] could not minimize browser window: %s", exc)
 
 
+def _describe_browser_start_error(exc: Exception, options: ChromiumOptions) -> str:
+    binary = getattr(options, "binary_location", None) or "<unset>"
+    try:
+        binary_exists = os.path.exists(binary)
+    except Exception:
+        binary_exists = False
+    env_binary = os.environ.get("CHROME_PATH") or os.environ.get("BRAVE_PATH") or "<unset>"
+    display = os.environ.get("DISPLAY") or "<unset>"
+    profile_dir = _get_profile_dir()
+    return (
+        "Browser failed to start inside pydoll/Chrome launch. "
+        f"binary={binary!r} binary_exists={binary_exists} "
+        f"configured_chrome_env={env_binary} display={display} "
+        f"profile_dir={profile_dir} start_timeout={getattr(options, 'start_timeout', 'n/a')}s "
+        f"OS={platform.system()} message={exc!r}"
+    )
+
+
 async def _solve_impl(
     sitekey: str,
     siteurl: str,
@@ -454,8 +500,23 @@ async def _solve_impl(
     hold_open_seconds: float = 0.0,
 ) -> str | tuple[str, str | None]:
     options = build_chromium_options(hidden=True)
-    browser = Chrome(options=options)
-    tab = await browser.start()
+    browser = None
+    try:
+        logger.info(
+            "[solver] launching browser through pydoll: binary=%s start_timeout=%ss",
+            options.binary_location,
+            getattr(options, "start_timeout", "n/a"),
+        )
+        browser = Chrome(options=options)
+        tab = await browser.start()
+    except Exception as exc:
+        message = _describe_browser_start_error(exc, options)
+        logger.error("[solver] %s", message)
+        raise RuntimeError(
+            "Browser failed to start. Verify the Chromium binary and Docker/host runtime; "
+            "the pydoll startup watchdog timed out or the browser process never became discoverable. "
+            "See the logs for the configured binary/profile/display details.",
+        ) from exc
     await _try_minimize_window(browser)
 
     callback_grant = _extract_grant_from_callback_url(siteurl)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,8 +27,8 @@ sleep 1
 # 2. Start Fluxbox window manager to keep Chromium windows organized
 fluxbox -display :99 >/dev/null 2>&1 &
 
-# 3. Start VNC server on port 5900 (no password, for local access)
-x11vnc -display :99 -forever -nopw -shared -bg -quiet
+# 3. Start VNC server on port 5900 (password, for local access)
+x11vnc -display :99 -forever -passwd "spotiflac" -shared -bg -quiet
 
 # 4. Start noVNC bridge to view the screen from a web browser on port 6080
 websockify --web=/usr/share/novnc --daemon 6080 localhost:5900 >/dev/null 2>&1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SpotiFLAC"
-version = "1.6.7"
+version = "1.6.8"
 description = "Get Spotify tracks in true FLAC from Tidal, Qobuz & Amazon Music — no account required."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_signed_session_timeout.py
+++ b/tests/test_signed_session_timeout.py
@@ -1,6 +1,10 @@
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+from pydoll.exceptions import FailedToStartBrowser
+
+import SpotiFLAC.core.solver as solver
 from SpotiFLAC.core.signed_session_mobile import perform_signed_fetch
 
 
@@ -38,3 +42,20 @@ def test_perform_signed_fetch_forwards_timeout_to_manual_grant() -> None:
         ]
 
     asyncio.run(run_test())
+
+
+def test_solver_wraps_browser_start_failure_with_clear_runtime_error(monkeypatch) -> None:
+    class FakeBrowser:
+        def __init__(self, options) -> None:
+            self.options = options
+
+        async def start(self):
+            raise FailedToStartBrowser()
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr(solver, "Chrome", FakeBrowser)
+
+    with pytest.raises(RuntimeError, match="Browser failed to start"):
+        asyncio.run(solver._solve_impl("sitekey", "https://example.com", 1))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Explicit tracks now include the appropriate advisory tag in downloaded FLAC metadata.
  * Browser startup timeout can be configured, with a 30-second default.
* **Bug Fixes**
  * Browser launch failures now provide clearer diagnostic error messages.
* **Security**
  * VNC access now requires the password `spotiflac`.
* **Chores**
  * Updated the application version to 1.6.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->